### PR TITLE
Added responsive header

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,6 +24,7 @@
         "react-router-dom": "^6.27.0",
         "tailwind-merge": "^2.5.4",
         "tailwindcss-animate": "^1.0.7",
+        "vaul": "^1.1.1",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -1119,6 +1120,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-dialog/-/react-dialog-1.1.2.tgz",
       "integrity": "sha512-Yj4dZtqa2o+kG61fzB0H2qUvmwBA2oyQroGLyNtBj1beo1khoQ3q1a2AO8rrQYjd8256CO9+N8L9tvsS+bnIyA==",
+      "license": "MIT",
       "dependencies": {
         "@radix-ui/primitive": "1.1.0",
         "@radix-ui/react-compose-refs": "1.1.0",
@@ -4610,6 +4612,19 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/vaul": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/vaul/-/vaul-1.1.1.tgz",
+      "integrity": "sha512-+ejzF6ffQKPcfgS7uOrGn017g39F8SO4yLPXbBhpC7a0H+oPqPna8f1BUfXaz8eU4+pxbQcmjxW+jWBSbxjaFg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-dialog": "^1.1.1"
+      },
+      "peerDependencies": {
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0"
+      }
     },
     "node_modules/vite": {
       "version": "5.4.10",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -26,6 +26,7 @@
     "react-router-dom": "^6.27.0",
     "tailwind-merge": "^2.5.4",
     "tailwindcss-animate": "^1.0.7",
+    "vaul": "^1.1.1",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/frontend/src/components/Header.tsx
+++ b/frontend/src/components/Header.tsx
@@ -1,0 +1,13 @@
+import { MainNav } from "@/components/MainNav"
+import { MobileNav } from "@/components/MobileNav"
+
+export function Header() {
+  return (
+    <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 dark:border-border">
+      <div className="flex h-14 items-center px-4">
+        <MainNav />
+        <MobileNav />
+      </div>
+    </header>
+  )
+}

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,5 +1,5 @@
 import { Outlet } from "react-router-dom";
-// import Header from "./Header"
+import { Header } from "./Header"
 // import Footer from "./Footer"
 import { Suspense } from "react";
 import { Toaster } from "./ui/toaster";
@@ -7,8 +7,8 @@ import { Toaster } from "./ui/toaster";
 export default function Layout() {
   return (
     <>
-      {/* <Header /> */}
-      <main className="flex h-screen w-screen items-center justify-center">
+      <Header />
+      <main className="flex full-height w-screen items-center justify-center">
         <Suspense fallback={<div>Loading...</div>}>
           <Outlet />
         </Suspense>

--- a/frontend/src/components/MainNav.tsx
+++ b/frontend/src/components/MainNav.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import { Link } from "react-router-dom";
+
+import SiteConfig from "@/config/site";
+import { navConfig } from "@/config/header-nav";
+import { cn } from "@/lib/utils";
+import { Icons } from "@/components/icons";
+
+export function MainNav() {
+  const pathname = location.pathname;
+  console.log(pathname);
+
+  return (
+    <div className="mr-4 hidden md:flex">
+      <Link to="/" className="mr-4 flex items-center space-x-2 lg:mr-6">
+        <Icons.logo className="h-6 w-6" />
+        <span className="hidden font-bold lg:inline-block">
+          {SiteConfig.name}
+        </span>
+      </Link>
+      <nav className="flex items-center gap-4 text-sm lg:gap-6">
+        {navConfig.mainNav?.map(
+          (item) => (
+            <Link
+              to={item.href}
+              className={cn(
+                "transition-colors hover:text-foreground/80",
+                pathname === item.href ? "text-foreground" : "text-foreground/60"
+              )}
+            >
+              {item.title}
+            </Link>
+          )
+        )}
+      </nav>
+    </div>
+  )
+}

--- a/frontend/src/components/MobileNav.tsx
+++ b/frontend/src/components/MobileNav.tsx
@@ -1,0 +1,98 @@
+"use client"
+
+import * as React from "react";
+import { Link, LinkProps, redirect } from "react-router-dom";
+
+import { navConfig } from "@/config/header-nav";
+import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerTrigger,
+} from "@/components/ui/drawer";
+
+export function MobileNav() {
+  const [open, setOpen] = React.useState(false);
+
+  const onOpenChange = React.useCallback(
+    (open: boolean) => {
+      setOpen(open)
+    },
+    [setOpen]
+  );
+
+  return (
+    <Drawer open={open} onOpenChange={onOpenChange}>
+      <DrawerTrigger asChild>
+        <Button
+          id="drawer-button"
+          variant="ghost"
+          className="-ml-2 mr-2 h-8 w-8 px-0 text-base md:hidden"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth="1.5"
+            stroke="currentColor"
+            className="!size-6"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              d="M3.75 9h16.5m-16.5 6.75h16.5"
+            />
+          </svg>
+          <span className="sr-only">Toggle Menu</span>
+        </Button>
+      </DrawerTrigger>
+      <DrawerContent className="max-h-[60svh] p-0">
+        <div className="overflow-auto p-6">
+          <div className="flex flex-col space-y-3">
+            {navConfig.mainNav?.map(
+              (item) =>
+                item.href && (
+                  <MobileLink
+                    key={item.href}
+                    to={item.href}
+                    onOpenChange={setOpen}
+                  >
+                    {item.title}
+                  </MobileLink>
+                )
+            )}
+          </div>
+        </div>
+      </DrawerContent>
+    </Drawer>
+  );
+}
+
+interface MobileLinkProps extends LinkProps {
+  onOpenChange?: (open: boolean) => void
+  children: React.ReactNode
+  className?: string
+}
+
+function MobileLink({
+  to,
+  onOpenChange,
+  className,
+  children,
+  ...props
+}: MobileLinkProps) {
+  return (
+    <Link
+      to={to}
+      onClick={() => {
+        redirect(to.toString())
+        onOpenChange?.(false)
+      }}
+      className={cn("text-base", className)}
+      {...props}
+    >
+      {children}
+    </Link>
+  );
+}

--- a/frontend/src/components/ui/drawer.tsx
+++ b/frontend/src/components/ui/drawer.tsx
@@ -1,0 +1,116 @@
+import * as React from "react"
+import { Drawer as DrawerPrimitive } from "vaul"
+
+import { cn } from "@/lib/utils"
+
+const Drawer = ({
+  shouldScaleBackground = true,
+  ...props
+}: React.ComponentProps<typeof DrawerPrimitive.Root>) => (
+  <DrawerPrimitive.Root
+    shouldScaleBackground={shouldScaleBackground}
+    {...props}
+  />
+)
+Drawer.displayName = "Drawer"
+
+const DrawerTrigger = DrawerPrimitive.Trigger
+
+const DrawerPortal = DrawerPrimitive.Portal
+
+const DrawerClose = DrawerPrimitive.Close
+
+const DrawerOverlay = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Overlay
+    ref={ref}
+    className={cn("fixed inset-0 z-50 bg-black/80", className)}
+    {...props}
+  />
+))
+DrawerOverlay.displayName = DrawerPrimitive.Overlay.displayName
+
+const DrawerContent = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DrawerPortal>
+    <DrawerOverlay />
+    <DrawerPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed inset-x-0 bottom-0 z-50 mt-24 flex h-auto flex-col rounded-t-[10px] border bg-background",
+        className
+      )}
+      {...props}
+    >
+      <div className="mx-auto mt-4 h-2 w-[100px] rounded-full bg-muted" />
+      {children}
+    </DrawerPrimitive.Content>
+  </DrawerPortal>
+))
+DrawerContent.displayName = "DrawerContent"
+
+const DrawerHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("grid gap-1.5 p-4 text-center sm:text-left", className)}
+    {...props}
+  />
+)
+DrawerHeader.displayName = "DrawerHeader"
+
+const DrawerFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("mt-auto flex flex-col gap-2 p-4", className)}
+    {...props}
+  />
+)
+DrawerFooter.displayName = "DrawerFooter"
+
+const DrawerTitle = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DrawerTitle.displayName = DrawerPrimitive.Title.displayName
+
+const DrawerDescription = React.forwardRef<
+  React.ElementRef<typeof DrawerPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DrawerPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DrawerPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DrawerDescription.displayName = DrawerPrimitive.Description.displayName
+
+export {
+  Drawer,
+  DrawerPortal,
+  DrawerOverlay,
+  DrawerTrigger,
+  DrawerClose,
+  DrawerContent,
+  DrawerHeader,
+  DrawerFooter,
+  DrawerTitle,
+  DrawerDescription,
+}

--- a/frontend/src/config/header-nav.ts
+++ b/frontend/src/config/header-nav.ts
@@ -1,0 +1,27 @@
+import PathConstants from "@/routes/pathConstants"
+import { MainNavItem } from "@/types/nav"
+
+export interface NavConfig {
+  mainNav: MainNavItem[]
+}
+
+export const navConfig: NavConfig = {
+  mainNav: [
+    // {
+    //   title: "Home",
+    //   href: PathConstants.HOME,
+    // },
+    {
+      title: "Login",
+      href: PathConstants.LOGIN,
+    },
+    {
+      title: "Register",
+      href: PathConstants.STUDENT_REGISTER,
+    },
+    {
+      title: "Become a teacher",
+      href: PathConstants.TEACHER_REGISTER,
+    },
+  ]
+}

--- a/frontend/src/config/site.ts
+++ b/frontend/src/config/site.ts
@@ -1,0 +1,5 @@
+const SiteConfig = {
+    name: 'Triolingo',
+};
+
+export default SiteConfig;

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -138,3 +138,26 @@ button:focus-visible {
     @apply bg-background text-foreground;
   }
 }
+
+
+#drawer-button {
+  background: var(--background);
+}
+
+
+#drawer-button:hover {
+  background: var(--background) !important;
+  border: none;
+}
+
+
+#drawer-button:focus {
+  background: var(--background);
+  border: none;
+  outline: none;
+}
+
+
+.full-height {
+  height: calc(100vh - 57px);
+}

--- a/frontend/src/types/nav.ts
+++ b/frontend/src/types/nav.ts
@@ -1,0 +1,18 @@
+import { Icons } from "@/components/icons"
+
+export interface NavItem {
+  title: string
+  href: string
+  disabled?: boolean
+  external?: boolean
+  icon?: keyof typeof Icons
+  label?: string
+}
+
+export interface NavItemWithChildren extends NavItem {
+  items: NavItemWithChildren[]
+}
+
+export interface MainNavItem extends NavItem {}
+
+export interface SidebarNavItem extends NavItemWithChildren {}


### PR DESCRIPTION
- Added basic responsive header
- added types and config

Desktop:
![image](https://github.com/user-attachments/assets/54d6fcf2-35ad-4267-a170-b299c0955c90)

Mobile collapsed:
![Screenshot 2024-11-06 at 17-51-27 Triolingo](https://github.com/user-attachments/assets/7a0883d4-861b-4d76-b930-0a40dbb8187c)

Mobile expanded:

![Screen Shot 2024-11-06 at 17 51 33](https://github.com/user-attachments/assets/a5ca56a3-cba6-4427-906e-ab4c9aeffdd4)
